### PR TITLE
Fix CSS for dark vs light mode

### DIFF
--- a/docs/media/style/customdoxygen.css
+++ b/docs/media/style/customdoxygen.css
@@ -39,9 +39,12 @@
     font-style: normal;
 }
 
-body {
-    background: #252525;
-    color: #dddddd;
+@media (prefers-color-scheme: dark) {
+    html {
+        --page-foreground-color: #dddddd;
+        --page-background-color: #252525;
+        --fragment-background-color: #111;
+    }
 }
 
 div.textblock {
@@ -57,12 +60,10 @@ div.textblock {
 }
 
 .alphachar a {
-    color: #dddddd;
     text-decoration: none;
 }
 
     .alphachar a:visited {
-        color: #dddddd;
         text-decoration: none;
     }
 
@@ -107,18 +108,15 @@ div hr {
 }
 
 div.header {
-    background: #252525;
     border: 0;
 }
 
 div.fragment {
-    background: #111111;
     padding: 5px;
     border: 1px solid #444444;
 }
 
 span.lineno {
-    background: #000000;
 }
 
 span.stringliteral {
@@ -159,12 +157,10 @@ a.codeRef, a.codeRef:visited, a.lineRef, a.lineRef:visited {
 }
 
 a.elRef {
-    color: #cccccc;
     text-decoration-color: blue;
 }
 
     a.elRef:visited {
-        color: #cccccc;
         text-decoration-color: blue;
     }
 
@@ -247,7 +243,6 @@ div.PageDoc h6::before {
     font-family: Montserrat;
     font-size: 32px;
     font-weight: bold;
-    color: #ffffff;
 }
 
 h2.groupheader {
@@ -285,15 +280,12 @@ code {
     border-right: 1px solid #444444;
     background: #1c1c1c;
     text-shadow: unset;
-    color: #dddddd;
 }
 
     .memproto a.el {
-        color: #dddddd;
     }
 
         .memproto a.el:visited {
-            color: #dddddd;
         }
 
 .paramtype {


### PR DESCRIPTION
Change the CSS overrides to rely on the existing Doxygen CSS variables and user-preferred theme (light or dark mode) instead of hard-coded dark-mode-only values.

Currently the docs pages only look good in dark mode. If the users prefer light mode, the docs are very hard to consume.

Doxygen actually already comes with viable values for the light mode. In order to properly support both, added an override for these variables for the dark mode and remove the hard-coded values wherever plausible.

# Screenshots

## Before - light mode

<img width="1840" alt="Screenshot 2024-12-01 at 10 53 47 am" src="https://github.com/user-attachments/assets/ac6af182-eae6-4f32-8d95-82498a0ea06b">

## Before - dark mode

<img width="1840" alt="Screenshot 2024-12-01 at 10 54 09 am" src="https://github.com/user-attachments/assets/9a0b3563-c2cc-4566-8ad5-007c252e5f3f">

## After - light mode

<img width="1840" alt="Screenshot 2024-12-01 at 10 54 37 am" src="https://github.com/user-attachments/assets/b7c8c42a-707b-4959-b0c9-233a24b3417c">

## After - dark mode

<img width="1840" alt="Screenshot 2024-12-01 at 10 54 42 am" src="https://github.com/user-attachments/assets/00995a04-53ba-4327-9d6f-aae224066b1a">
