### PR TITLE
updates to unblock the CI runs on the style-set-name branch

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "HikoGui DevBox",
-    "image": "ghcr.io/jakoch/cpp-devbox:with-vulkansdk-latest",
+    "image": "ghcr.io/jakoch/cpp-devbox:trixie-with-vulkansdk-1.0.8",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -56,10 +56,10 @@ jobs:
 
       - name: 🛠️ Setup Visual Studio Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
-    
+
       - name: 🔽 Install Vulkan SDK
-        uses: jakoch/install-vulkan-sdk-action@v1.0.3 # https://github.com/jakoch/install-vulkan-sdk-action/
-        with: 
+        uses: jakoch/install-vulkan-sdk-action@v1.1.1 # https://github.com/jakoch/install-vulkan-sdk-action/
+        with:
           vulkan_version: latest
           optional_components: com.lunarg.vulkan.vma
           install_runtime: true
@@ -94,7 +94,7 @@ jobs:
       - name: ✏ CMake ➔ Make Build Directory
         shell: pwsh
         run: mkdir "${{env.BUILD_DIR}}"
-    
+
       # The Vulkan Runtime is normally to be found in "C:\windows\systems32", but it's not a system library on CI.
       - name: 🔽 Install Vulkan Runtime in build directory
         working-directory: ${{env.BUILD_DIR}}
@@ -116,7 +116,7 @@ jobs:
       - name: 🙏 CMake ➔ Build Debug
         working-directory: ${{env.BUILD_DIR}}
         run: cmake --build . --config Debug --parallel 1
-    
+
       - name: ✔ ❌✔️ Hiko-Test Debug
         working-directory: ${{env.BUILD_DIR}}
         run: Debug\hikogui_htests-dbg "--gtest_output=xml:${{github.workspace}}\result_htests_deb_${{env.MATRIX_ID}}.xml"
@@ -124,11 +124,11 @@ jobs:
       - name: 📦 CMake ➔ Install Debug
         working-directory: ${{env.BUILD_DIR}}
         run: cmake --install . --config Debug
-  
+
       - name: 🙏 CMake ➔ Build RelWithDebInfo
         working-directory: ${{env.BUILD_DIR}}
         run: cmake --build . --config RelWithDebInfo --parallel 1
-    
+
       - name: ✔ ❌✔️ Hiko-Test RelWithDebInfo
         working-directory: ${{env.BUILD_DIR}}
         run: RelWithDebInfo\hikogui_htests-rdi "--gtest_output=xml:${{github.workspace}}\result_htests_rdi_${{env.MATRIX_ID}}.xml"
@@ -140,7 +140,7 @@ jobs:
       - name: 🙏 CMake ➔ Build Release
         working-directory: ${{env.BUILD_DIR}}
         run: cmake --build . --config Release --parallel 1
-    
+
       - name: ✔ ❌✔️ Hiko-Test Release
         working-directory: ${{env.BUILD_DIR}}
         run: Release\hikogui_htests-rel "--gtest_output=xml:${{github.workspace}}\result_htests_rel${{env.MATRIX_ID}}.xml"

--- a/.github/workflows/publish-PR-test-results.yml
+++ b/.github/workflows/publish-PR-test-results.yml
@@ -46,7 +46,7 @@ jobs:
           unzip -d tests test_results.zip
 
       - name: 👌 Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2 # https://github.com/EnricoMi/publish-unit-test-result-action
+        uses: EnricoMi/publish-unit-test-result-action/linux@v2 # https://github.com/EnricoMi/publish-unit-test-result-action
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
           junit_files: tests/**/test_results*.xml


### PR DESCRIPTION
- This applies the PRs #715 and #716 which target the main to the style-set-name branch.
  This should unblock CI.
- Additonally the cpp-devbox version is raised to a newer version.